### PR TITLE
Fix problem with hosts in the ingress.yaml file

### DIFF
--- a/ingress.yaml
+++ b/ingress.yaml
@@ -10,7 +10,7 @@ spec:
     servicePort: 80
   rules:
   - host: laravel-kubernetes.demo
-  - http:
+    http:
       paths:
       - path: /
         backend:


### PR DESCRIPTION
According to the spec: 
https://kubernetes.io/docs/concepts/services-networking/ingress/

http should be on the same level as host.